### PR TITLE
feat: calculate distribution on server side

### DIFF
--- a/src/features/admin/components/CalculationForm.tsx
+++ b/src/features/admin/components/CalculationForm.tsx
@@ -83,7 +83,7 @@ function MinimumQuorum() {
 
 function VoterCount() {
   const voters = useVoters();
-  const votes = api.results.votes.useQuery();
+  const totalVoters = api.results.totalVoters.useQuery();
 
   return (
     <div className="mb-4 flex flex-col items-center">
@@ -93,9 +93,9 @@ function VoterCount() {
       <div className="pt-1 text-center text-2xl">
         <Skeleton
           className="h-8 w-20 dark:bg-gray-700"
-          isLoading={voters.isPending || votes.isPending}
+          isLoading={voters.isPending || totalVoters.isPending}
         >
-          {votes.data?.totalVoters} / {voters.data?.length}
+          {totalVoters.data} / {voters.data?.length}
         </Skeleton>
       </div>
     </div>

--- a/src/features/ballot/types/index.ts
+++ b/src/features/ballot/types/index.ts
@@ -32,5 +32,5 @@ export const BallotV2Schema = z.object({
   allocations: z.array(AllocationSchema),
 });
 
-export type Allocation = z.infer<typeof AllocationSchema>;
+export type Allocation = z.input<typeof AllocationSchema>;
 export type BallotV2 = z.infer<typeof BallotV2Schema>;

--- a/src/features/distribute/components/Distributions.tsx
+++ b/src/features/distribute/components/Distributions.tsx
@@ -36,9 +36,6 @@ export function Distributions() {
 
   const totalTokens = poolAmount.data?.toString() ?? "0";
 
-  const votes = api.results.votes.useQuery();
-  console.log("votes", votes.data);
-
   const distributionResult = api.results.distribution.useQuery({ totalTokens });
 
   if (distributionResult.isPending) {
@@ -69,7 +66,6 @@ export function Distributions() {
         })}
         values={{ votes: distributions }}
         onSubmit={(values) => {
-          console.log("Distribute", values.votes[0]);
           setConfirmDistribution(values.votes);
         }}
       >

--- a/src/features/distribute/components/Distributions.tsx
+++ b/src/features/distribute/components/Distributions.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { z } from "zod";
-import { formatUnits } from "viem";
 
 import { EmptyState } from "~/components/EmptyState";
 import { Button } from "~/components/ui/Button";
@@ -16,7 +15,6 @@ import { api } from "~/utils/api";
 import { usePoolAmount } from "../hooks/useAlloPool";
 import { ConfirmDistributionDialog } from "./ConfirmDistributionDialog";
 import { ExportCSV } from "./ExportCSV";
-import { calculatePayout } from "../utils/calculatePayout";
 import { formatNumber } from "~/utils/formatNumber";
 import { format } from "~/utils/csv";
 import { ImportCSV } from "./ImportCSV";
@@ -27,54 +25,36 @@ export function Distributions() {
   >([]);
 
   const poolAmount = usePoolAmount();
-  const votes = api.results.votes.useQuery();
-  console.log("votes", votes.data);
 
-  const projectIds = Object.keys(votes.data?.projects ?? {});
-
-  const projects = api.projects.payoutAddresses.useQuery(
-    { ids: projectIds },
-    { enabled: Boolean(projectIds.length) },
-  );
-
-  const payoutAddresses: Record<string, string> = projects.data ?? {};
-  const totalVotes = BigInt(votes.data?.totalVotes ?? 0);
-  const totalTokens = poolAmount.data ?? 0n;
-  const projectVotes = votes.data?.projects ?? {};
-  const distributions = useMemo(
-    () =>
-      projectIds
-        ?.map((projectId) => ({
-          projectId,
-          payoutAddress: payoutAddresses[projectId] ?? "",
-          amount: projectVotes[projectId]?.votes ?? 0,
-        }))
-        .filter((p) => p.amount > 0)
-        .sort((a, b) => b.amount - a.amount)
-        .map((p) => ({
-          ...p,
-          amount:
-            totalTokens > 0n
-              ? parseFloat(
-                  formatUnits(
-                    calculatePayout(p.amount, totalVotes, totalTokens),
-                    18,
-                  ),
-                )
-              : p.amount,
-        })),
-    [projectIds, payoutAddresses, projectVotes, totalVotes, totalTokens],
-  );
-
-  if (!votes.isPending && !projectIds.length) {
-    return <EmptyState title="No project votes found" />;
-  }
-  if (projects.isPending ?? votes.isPending ?? poolAmount.isPending) {
+  if (poolAmount.isPending) {
     return (
       <div className="flex h-full items-center justify-center">
         <Spinner className="size-6" />
       </div>
     );
+  }
+
+  const totalTokens = poolAmount.data?.toString() ?? "0";
+
+  const votes = api.results.votes.useQuery();
+  console.log("votes", votes.data);
+
+  const distributionResult = api.results.distribution.useQuery({ totalTokens });
+
+  if (distributionResult.isPending) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner className="size-6" />
+      </div>
+    );
+  }
+
+  const distributions = distributionResult.data?.distributions || [];
+  const projectIds = distributionResult.data?.projectIds || [];
+  const totalVotes = distributionResult.data?.totalVotes;
+
+  if (!projectIds.length) {
+    return <EmptyState title="No project votes found" />;
   }
 
   if (!distributions.length) {
@@ -105,7 +85,7 @@ export function Distributions() {
           </div>
         </div>
         <div className="flex items-center gap-4">
-          <div>Total votes: {formatNumber(votes.data?.totalVotes)}</div>
+          <div>Total votes: {formatNumber(totalVotes)}</div>
           <ExportVotes />
         </div>
         <div className="min-h-[360px] overflow-auto">

--- a/src/features/distribute/utils/calculatePayout.tsx
+++ b/src/features/distribute/utils/calculatePayout.tsx
@@ -1,7 +1,0 @@
-export function calculatePayout(
-  votes: number,
-  totalVotes: bigint,
-  totalTokens: bigint,
-) {
-  return (BigInt(Math.round(votes * 100)) * totalTokens) / totalVotes / 100n;
-}

--- a/src/server/api/routers/results.ts
+++ b/src/server/api/routers/results.ts
@@ -4,14 +4,83 @@ import {
   attestationProcedure,
   roundProcedure,
   createTRPCRouter,
+  adminAttestationProcedure,
 } from "~/server/api/trpc";
 import { FilterSchema } from "~/features/filter/types";
-import { calculateVotes } from "~/utils/calculateResults";
+import { BallotResults, calculateVotes } from "~/utils/calculateResults";
 import { TRPCError } from "@trpc/server";
 import { getState } from "~/features/rounds/hooks/useRoundState";
 import { RoundTypes } from "~/features/rounds/types";
+import { formatUnits } from "viem";
+import { z } from "zod";
+import { fetchMetadata } from "~/utils/fetchMetadata";
 
 export const resultsRouter = createTRPCRouter({
+  distribution: adminAttestationProcedure
+    .input(
+      z.object({
+        totalTokens: z.string(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const votes = await calculateBallotResults(ctx);
+
+      const totalVotes = votes.totalVotes;
+      const projectVotes = votes.votes ?? {};
+      const projectIds = Object.keys(votes.votes ?? {});
+
+      let totalTokens = 0n;
+
+      try {
+        totalTokens = BigInt(input.totalTokens);
+      } catch (error) {
+        throw new Error("Invalid totalTokens value, can not convert to bigint");
+      }
+
+      const payoutAddresses = await ctx
+        .fetchAttestations(["metadata"], {
+          where: { id: { in: projectIds } },
+        })
+        .then((attestations) =>
+          Promise.all(
+            attestations.map((attestation) =>
+              fetchMetadata(attestation.metadataPtr).then((data) => {
+                const { payoutAddress } = data as unknown as {
+                  payoutAddress: string;
+                };
+
+                console.log({ payoutAddress });
+                return { projectId: attestation.id, payoutAddress };
+              }),
+            ),
+          ),
+        )
+        .then((projects) =>
+          projects.reduce(
+            (acc, x) => ({ ...acc, [x.projectId]: x.payoutAddress }),
+            {},
+          ),
+        );
+
+      const distributions = calculateDistributionsByProject({
+        projectIds,
+        projectVotes,
+        totalTokens,
+        totalVotes,
+        payoutAddresses,
+      });
+
+      return { totalVotes, projectIds, distributions };
+    }),
+  totalVoters: adminProcedure.query(async ({ ctx }) => {
+    const roundId = ctx.round?.id || "";
+    const { db } = ctx;
+    const ballots = await db.ballot.findMany({
+      where: { roundId, publishedAt: { not: null } },
+      select: { voterId: true, votes: true },
+    });
+    return ballots.length;
+  }),
   votes: adminProcedure.query(async ({ ctx }) => calculateBallotResults(ctx)),
   results: roundProcedure.query(async ({ ctx }) => {
     const round = await ctx.db.round.findFirst({ where: { id: ctx.round.id } });
@@ -97,4 +166,51 @@ async function calculateBallotResults({
   const totalVoters = ballots.length;
 
   return { votes, totalVoters, totalVotes, averageVotes };
+}
+
+function calculateDistributionsByProject({
+  projectIds,
+  payoutAddresses,
+  projectVotes,
+  totalVotes,
+  totalTokens,
+}: {
+  projectIds: Array<string>;
+  payoutAddresses: Record<string, string>;
+  projectVotes: BallotResults;
+  totalVotes: number;
+  totalTokens: bigint;
+}) {
+  return projectIds
+    ?.map((projectId) => ({
+      projectId,
+      payoutAddress: payoutAddresses[projectId] ?? "",
+      amount: projectVotes[projectId]?.allocations ?? 0,
+    }))
+    .filter((p) => p.amount > 0)
+    .sort((a, b) => b.amount - a.amount)
+    .map((p) => {
+      return {
+        ...p,
+        amount:
+          totalTokens > 0n
+            ? parseFloat(
+                formatUnits(
+                  calculatePayout(p.amount, totalVotes, totalTokens),
+                  18,
+                ),
+              )
+            : p.amount,
+      };
+    });
+}
+
+function calculatePayout(
+  votes: number,
+  totalVotes: number,
+  totalTokens: bigint,
+) {
+  return (
+    (BigInt(Math.round(votes * 100)) * totalTokens) / BigInt(totalVotes) / 100n
+  );
 }

--- a/src/server/api/routers/results.ts
+++ b/src/server/api/routers/results.ts
@@ -49,7 +49,6 @@ export const resultsRouter = createTRPCRouter({
                   payoutAddress: string;
                 };
 
-                console.log({ payoutAddress });
                 return { projectId: attestation.id, payoutAddress };
               }),
             ),

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -124,15 +124,6 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
  */
 export const createTRPCRouter = t.router;
 
-/**
- * Public (unauthenticated) procedure
- *
- * This is the base piece you use to build new queries and mutations on your tRPC API. It does not
- * guarantee that a user querying is authorized, but you can still access user session data if they
- * are logged in.
- */
-export const publicProcedure = t.procedure;
-
 /** Reusable middleware that enforces users are logged in before running the procedure. */
 const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
   if (!ctx.session?.user) {
@@ -151,33 +142,35 @@ const roundMiddleware = t.middleware(async ({ ctx, next }) => {
   // TODO: should really be replaced with roundId
   const domain = ctx.domain;
 
-  const round = domain
-    ? await ctx.db.round.findFirst({
-        where: { domain },
-        select: {
-          id: true,
-          admins: true,
-          network: true,
-          type: true,
-          startsAt: true,
-          reviewAt: true,
-          votingAt: true,
-          resultAt: true,
-          calculationConfig: true,
-          calculationType: true,
-          payoutAt: true,
-          maxVotesProject: true,
-          maxVotesTotal: true,
-          metrics: true,
-        },
-      })
-    : null;
+  if (!domain)
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Domain is required" });
+
+  const round = await ctx.db.round.findFirst({
+    where: { domain },
+    select: {
+      id: true,
+      admins: true,
+      network: true,
+      type: true,
+      startsAt: true,
+      reviewAt: true,
+      votingAt: true,
+      resultAt: true,
+      calculationConfig: true,
+      calculationType: true,
+      payoutAt: true,
+      maxVotesProject: true,
+      maxVotesTotal: true,
+      metrics: true,
+    },
+  });
 
   if (!round)
     throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
 
-  return next({ ctx: { ...ctx, round } });
+  return next({ ctx: { ...ctx, round: round as Round } });
 });
+
 const attestationMiddleware = t.middleware(async ({ ctx, next }) => {
   if (!ctx.round)
     throw new TRPCError({ code: "BAD_REQUEST", message: "No round found" });
@@ -185,6 +178,7 @@ const attestationMiddleware = t.middleware(async ({ ctx, next }) => {
   return next({
     ctx: {
       ...ctx,
+      round: ctx.round,
       fetchAttestations: createAttestationFetcher(ctx.round),
     },
   });
@@ -202,6 +196,34 @@ const enforceUserIsAdmin = t.middleware(({ ctx, next }) => {
 });
 
 /**
+ * Public (unauthenticated) procedure
+ *
+ * This is the base piece you use to build new queries and mutations on your tRPC API. It does not
+ * guarantee that a user querying is authorized, but you can still access user session data if they
+ * are logged in.
+ */
+export const publicProcedure = t.procedure;
+
+/**
+ * Public Procedure that uses roundMiddleware to add round data to the context.
+ *
+ * This procedure is accessible to anyone and includes the round data in the context,
+ * allowing the handling of round-specific logic.
+ */
+export const roundProcedure = publicProcedure.use(roundMiddleware);
+
+/**
+ * Public Procedure that uses roundMiddleware to add round data to the context,
+ * and attestationMiddleware to add attestation data to the context.
+ *
+ * This procedure is accessible to anyone and includes both round and attestation data
+ * in the context, allowing the handling of more complex logic involving attestations.
+ */
+export const attestationProcedure = publicProcedure
+  .use(roundMiddleware)
+  .use(attestationMiddleware);
+
+/**
  * Protected (authenticated) procedure
  *
  * If you want a query or mutation to ONLY be accessible to logged in users, use this. It verifies
@@ -209,14 +231,23 @@ const enforceUserIsAdmin = t.middleware(({ ctx, next }) => {
  *
  * @see https://trpc.io/docs/procedures
  */
-
 export const protectedProcedure = t.procedure.use(enforceUserIsAuthed);
-export const roundProcedure = t.procedure.use(roundMiddleware);
-export const protectedRoundProcedure = t.procedure
-  .use(roundMiddleware)
-  .use(enforceUserIsAuthed);
 
-export const ballotProcedure = protectedRoundProcedure.use(
+/**
+ * Protected Procedure that uses roundMiddleware to add round data to the context.
+ *
+ * This procedure is accessible only to authenticated users and includes the round data in the context,
+ * allowing the handling of round-specific logic for authenticated users.
+ */
+export const protectedRoundProcedure = protectedProcedure.use(roundMiddleware);
+
+/**
+ * Protected Procedure that uses roundMiddleware to add round data to the context and ballot data.
+ *
+ * This procedure is accessible only to authenticated users and includes both round and ballot data
+ * in the context, allowing the handling of more complex logic involving ballots.
+ */
+export const ballotProcedure = protectedProcedure.use(roundMiddleware).use(
   t.middleware(async ({ ctx, next }) => {
     const voterId = ctx.session?.user.name!;
     const roundId = ctx.round?.id!;
@@ -234,12 +265,37 @@ export const ballotProcedure = protectedRoundProcedure.use(
     });
   }),
 );
+
+/**
+ * Protected Procedure that uses enforceUserIsAdmin to ensure the user is an admin,
+ * and roundMiddleware to add round data to the context.
+ *
+ * This procedure is accessible only to authenticated users who are also admins, and includes
+ * the round data in the context, allowing the handling of admin-specific logic for the round.
+ */
 export const adminProcedure = protectedProcedure
+  .use(enforceUserIsAdmin)
+  .use(roundMiddleware);
+
+/**
+ * Protected Procedure that uses enforceUserIsAdmin to ensure the user is an admin,
+ * roundMiddleware to add round data to the context, and attestationMiddleware to add attestation data.
+ *
+ * This procedure is accessible only to authenticated users who are also admins, and includes both
+ * round and attestation data in the context, allowing the handling of admin-specific logic involving
+ * attestations.
+ */
+export const adminAttestationProcedure = protectedProcedure
+  .use(enforceUserIsAdmin)
   .use(roundMiddleware)
-  .use(enforceUserIsAdmin);
+  .use(attestationMiddleware);
 
-export const attestationProcedure = roundProcedure.use(attestationMiddleware);
-
+/**
+ * Helper function to validate the API key and retrieve the corresponding session.
+ *
+ * @param apiKey - The API key to validate.
+ * @returns The session if the API key is valid, otherwise null.
+ */
 export async function getApiKeySession(apiKey?: string | null) {
   if (!apiKey) return null;
 

--- a/src/utils/calculateResults.test.ts
+++ b/src/utils/calculateResults.test.ts
@@ -191,7 +191,6 @@ describe("Calculate results", () => {
     const actual = calculateVotes([], {
       calculation: "sum",
     });
-    console.log("No allocations", actual);
     expect(actual).toEqual({});
   });
 
@@ -218,7 +217,6 @@ describe("Calculate results", () => {
     const actual = calculateVotes(ballotsSingleVoterSingleProject, {
       calculation: "sum",
     });
-    console.log("Single voter single project", actual);
     expect(actual).toEqual({
       projectA: {
         allocations: 21,
@@ -231,7 +229,6 @@ describe("Calculate results", () => {
     const actual = calculateVotes(ballotsMultipleVotersSingleProject, {
       calculation: "sum",
     });
-    console.log("Multiple voters single project", actual);
     expect(actual).toEqual({
       projectA: {
         allocations: 50,

--- a/src/utils/calculateResults.test.ts
+++ b/src/utils/calculateResults.test.ts
@@ -1,98 +1,321 @@
 import { describe, expect, test } from "vitest";
 import { calculateVotes } from "./calculateResults";
+import { Allocation } from "~/features/ballot/types";
+
+const ballots: { voterId: string; allocations: Allocation[] }[] = [
+  {
+    voterId: "voterA",
+    allocations: [
+      {
+        id: "projectA",
+        amount: 21,
+      },
+      {
+        id: "projectB",
+        amount: 32,
+      },
+    ],
+  },
+  {
+    voterId: "voterB",
+    allocations: [
+      {
+        id: "projectA",
+        amount: 22,
+      },
+      {
+        id: "projectB",
+        amount: 54,
+      },
+    ],
+  },
+  {
+    voterId: "voterC",
+    allocations: [
+      {
+        id: "projectA",
+        amount: 34,
+      },
+      {
+        id: "projectB",
+        amount: 41,
+      },
+      {
+        id: "projectC",
+        amount: 65,
+      },
+    ],
+  },
+  {
+    voterId: "voterD",
+    allocations: [
+      {
+        id: "projectA",
+        amount: 37,
+      },
+      {
+        id: "projectC",
+        amount: 70,
+      },
+    ],
+  },
+];
+
+const ballotsSingleVoterSingleProject: {
+  voterId: string;
+  allocations: Allocation[];
+}[] = [
+  {
+    voterId: "voterA",
+    allocations: [
+      {
+        id: "projectA",
+        amount: 21,
+      },
+    ],
+  },
+];
+
+const ballotsMultipleVotersSingleProject: {
+  voterId: string;
+  allocations: Allocation[];
+}[] = [
+  {
+    voterId: "voterA",
+    allocations: [
+      {
+        id: "projectA",
+        amount: 21,
+      },
+    ],
+  },
+  {
+    voterId: "voterB",
+    allocations: [
+      {
+        id: "projectA",
+        amount: 29,
+      },
+    ],
+  },
+];
 
 describe("Calculate results", () => {
-  const ballots = [
-    {
-      voterId: "voterA",
-      votes: [
-        {
-          projectId: "projectA",
-          amount: 20,
-        },
-        {
-          projectId: "projectB",
-          amount: 30,
-        },
-      ],
-    },
-    {
-      voterId: "voterB",
-      votes: [
-        {
-          projectId: "projectA",
-          amount: 22,
-        },
-        {
-          projectId: "projectB",
-          amount: 50,
-        },
-      ],
-    },
-    {
-      voterId: "voterC",
-      votes: [
-        {
-          projectId: "projectA",
-          amount: 30,
-        },
-        {
-          projectId: "projectB",
-          amount: 40,
-        },
-        {
-          projectId: "projectC",
-          amount: 60,
-        },
-      ],
-    },
-    {
-      voterId: "voterD",
-      votes: [
-        {
-          projectId: "projectA",
-          amount: 35,
-        },
-        {
-          projectId: "projectC",
-          amount: 70,
-        },
-      ],
-    },
-  ];
-  test("custom payout", () => {
-    const actual = calculateVotes(ballots, { style: "custom" });
-    console.log(actual);
+  test("Sum payout", () => {
+    const actual = calculateVotes(ballots, {
+      calculation: "sum",
+      threshold: 2,
+    });
 
     expect(actual).toMatchInlineSnapshot(`
       {
         "projectA": {
+          "allocations": 114,
           "voters": 4,
-          "votes": 107,
         },
         "projectB": {
+          "allocations": 127,
           "voters": 3,
-          "votes": 120,
         },
         "projectC": {
+          "allocations": 135,
           "voters": 2,
-          "votes": 130,
         },
       }
     `);
   });
-  test("OP-style payout", () => {
-    const actual = calculateVotes(ballots, { style: "op", threshold: 3 });
-    console.log(actual);
+
+  test("Median payout", () => {
+    const actual = calculateVotes(ballots, {
+      calculation: "median",
+      threshold: 3,
+    });
+
     expect(actual).toMatchInlineSnapshot(`
       {
         "projectA": {
+          "allocations": 28,
           "voters": 4,
-          "votes": 26,
         },
         "projectB": {
+          "allocations": 41,
           "voters": 3,
-          "votes": 40,
+        },
+      }
+    `);
+  });
+
+  test("Average payout", () => {
+    const calculationThreshold3 = calculateVotes(ballots, {
+      calculation: "average",
+      threshold: 3,
+    });
+
+    expect(calculationThreshold3).toMatchInlineSnapshot(`
+      {
+        "projectA": {
+          "allocations": 28,
+          "voters": 4,
+        },
+        "projectB": {
+          "allocations": 42,
+          "voters": 3,
+        },
+      }
+    `);
+
+    const calculationThreshold2 = calculateVotes(ballots, {
+      calculation: "average",
+      threshold: 2,
+    });
+
+    expect(calculationThreshold2).toMatchInlineSnapshot(`
+      {
+        "projectA": {
+          "allocations": 28,
+          "voters": 4,
+        },
+        "projectB": {
+          "allocations": 42,
+          "voters": 3,
+        },
+        "projectC": {
+          "allocations": 67,
+          "voters": 2,
+        },
+      }
+    `);
+  });
+
+  test("No allocations", () => {
+    const actual = calculateVotes([], {
+      calculation: "sum",
+    });
+    console.log("No allocations", actual);
+    expect(actual).toEqual({});
+  });
+
+  test("Threshold not met", () => {
+    const sumCalculation = calculateVotes(ballots, {
+      calculation: "sum",
+      threshold: 5,
+    });
+    const medianCalculation = calculateVotes(ballots, {
+      calculation: "median",
+      threshold: 5,
+    });
+    const averageCalculation = calculateVotes(ballots, {
+      calculation: "average",
+      threshold: 5,
+    });
+
+    expect(sumCalculation).toEqual({});
+    expect(medianCalculation).toEqual({});
+    expect(averageCalculation).toEqual({});
+  });
+
+  test("Single voter single project", () => {
+    const actual = calculateVotes(ballotsSingleVoterSingleProject, {
+      calculation: "sum",
+    });
+    console.log("Single voter single project", actual);
+    expect(actual).toEqual({
+      projectA: {
+        allocations: 21,
+        voters: 1,
+      },
+    });
+  });
+
+  test("Multiple voters single project", () => {
+    const actual = calculateVotes(ballotsMultipleVotersSingleProject, {
+      calculation: "sum",
+    });
+    console.log("Multiple voters single project", actual);
+    expect(actual).toEqual({
+      projectA: {
+        allocations: 50,
+        voters: 2,
+      },
+    });
+  });
+
+  test("Average payout with different thresholds", () => {
+    const actualThreshold0 = calculateVotes(ballots, {
+      calculation: "average",
+      threshold: 0,
+    });
+    const actualThreshold1 = calculateVotes(ballots, {
+      calculation: "average",
+      threshold: 1,
+    });
+    const actualThreshold2 = calculateVotes(ballots, {
+      calculation: "average",
+      threshold: 2,
+    });
+    const actualThreshold3 = calculateVotes(ballots, {
+      calculation: "average",
+      threshold: 3,
+    });
+    const actualThreshold4 = calculateVotes(ballots, {
+      calculation: "average",
+      threshold: 4,
+    });
+
+    expect(actualThreshold0).toMatchInlineSnapshot(`
+      {
+        "projectA": {
+          "allocations": 28,
+          "voters": 4,
+        },
+        "projectB": {
+          "allocations": 42,
+          "voters": 3,
+        },
+        "projectC": {
+          "allocations": 67,
+          "voters": 2,
+        },
+      }
+    `);
+
+    expect(actualThreshold1).toEqual(actualThreshold0);
+
+    expect(actualThreshold2).toMatchInlineSnapshot(`
+      {
+        "projectA": {
+          "allocations": 28,
+          "voters": 4,
+        },
+        "projectB": {
+          "allocations": 42,
+          "voters": 3,
+        },
+        "projectC": {
+          "allocations": 67,
+          "voters": 2,
+        },
+      }
+    `);
+
+    expect(actualThreshold3).toMatchInlineSnapshot(`
+      {
+        "projectA": {
+          "allocations": 28,
+          "voters": 4,
+        },
+        "projectB": {
+          "allocations": 42,
+          "voters": 3,
+        },
+      }
+    `);
+
+    expect(actualThreshold4).toMatchInlineSnapshot(`
+      {
+        "projectA": {
+          "allocations": 28,
+          "voters": 4,
         },
       }
     `);

--- a/src/utils/calculateResults.ts
+++ b/src/utils/calculateResults.ts
@@ -1,4 +1,4 @@
-import { Allocation, type Vote } from "~/features/ballot/types";
+import type { Allocation } from "~/features/ballot/types";
 
 export type PayoutOptions = {
   calculation: "average" | "median" | "sum";
@@ -15,6 +15,8 @@ export function calculateVotes(
   ballots: { voterId: string; allocations: Allocation[] }[],
   payoutOpts: PayoutOptions,
 ): BallotResults {
+  const { calculation: calculationType, threshold = 0 } = payoutOpts;
+
   const votes: Record<
     string,
     {
@@ -48,13 +50,12 @@ export function calculateVotes(
 
   for (const id in votes) {
     const { amounts, voterIds } = votes[id]!;
-    const voteIsCounted =
-      payoutOpts.threshold && voterIds.size >= payoutOpts.threshold;
+    const voteIsCounted = voterIds.size >= threshold;
 
     if (voteIsCounted) {
       projects[id] = {
         voters: voterIds.size,
-        allocations: calcFunctions[payoutOpts.calculation ?? "average"]?.(
+        allocations: calcFunctions[calculationType ?? "average"]?.(
           amounts.sort((a, b) => a - b),
         ),
       };
@@ -75,7 +76,7 @@ function calculateAverage(arr: number[]) {
   const sum = arr.reduce((sum, x) => sum + x, 0);
   const average = sum / arr.length;
 
-  return Math.round(average);
+  return Math.floor(average);
 }
 
 function calculateMedian(arr: number[]): number {


### PR DESCRIPTION
changes:
- refactored tRPC server to have the right middleware order and implemented adminAttestationProcedure
- changed Allocation type from `z.infer` to `z.input` to ensure `locked` property is recognized as optional
- implemented new `distribution` results router query to handle token distribution calculations on the server side
- implemented new `totalVoters` results router query to return the number of voters for a round
- refactored calculateResults, changing calculateAverage to use Math.floor
- refactored Distributions component to use the new distribution api query
- refactored Calculation form to use the new totalVoters api query