### PR TITLE
fix(RED-41): missing ballots on distribution page

### DIFF
--- a/src/utils/calculateResults.ts
+++ b/src/utils/calculateResults.ts
@@ -47,8 +47,9 @@ export function calculateVotes(
   };
   for (const projectId in projectVotes) {
     const { amounts, voterIds } = projectVotes[projectId]!;
-    const voteIsCounted =
-      payoutOpts.threshold && voterIds.size >= payoutOpts.threshold;
+
+    const { threshold = 0 } = payoutOpts;
+    const voteIsCounted = voterIds.size >= threshold;
 
     if (voteIsCounted) {
       projects[projectId] = {


### PR DESCRIPTION
- Ensure voteIsCounted is true when payoutOpts.threshold is 0.
- Updated logic to check if payoutOpts.threshold is defined and not null.