### PR TITLE
fix(RED-42): filter ballot query by roundId

### DIFF
--- a/src/server/api/routers/ballot.ts
+++ b/src/server/api/routers/ballot.ts
@@ -44,8 +44,9 @@ export const ballotRouter = createTRPCRouter({
       }));
   }),
   export: adminProcedure.mutation(({ ctx }) => {
+    const roundId = ctx.round?.id;
     return ctx.db.ballot
-      .findMany({ where: { publishedAt: { not: null } } })
+      .findMany({ where: { publishedAt: { not: null }, roundId } })
       .then(async (ballots) => {
         // Get all unique projectIds from all the votes
         const projectIds = Object.keys(


### PR DESCRIPTION
The issue was that we were getting a CSV with projects not related with the round, and some had name undefined, that is what users complained, but actually we were getting data unrelated to the round.