### PR TITLE
fix(RED-50): Ensure non-admins can see votes when round is in RESULTS state

### DIFF
--- a/src/features/projects/components/Projects.tsx
+++ b/src/features/projects/components/Projects.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import clsx from "clsx";
 import Link from "next/link";
 import { XIcon } from "lucide-react";
@@ -63,7 +65,9 @@ export function Projects() {
                   />
                 </div>
               ) : null}
-              {!results.isPending && roundState === "RESULTS" ? (
+              {!results.isPending &&
+              !results.error &&
+              roundState === "RESULTS" ? (
                 <ProjectItemAwarded
                   amount={results.data?.projects?.[item.id]?.votes}
                 />

--- a/src/hooks/useResults.ts
+++ b/src/hooks/useResults.ts
@@ -3,7 +3,7 @@ import { useRoundState } from "~/features/rounds/hooks/useRoundState";
 import { api } from "~/utils/api";
 
 export function useResults() {
-  return api.results.votes.useQuery();
+  return api.results.results.useQuery();
 }
 
 const seed = 0;
@@ -15,7 +15,7 @@ export function useProjectsResults() {
 }
 
 export function useProjectResults(id: string) {
-  const query = api.results.votes.useQuery(undefined, {
+  const query = api.results.results.useQuery(undefined, {
     enabled: useRoundState() === "RESULTS",
   });
   const project = query.data?.projects?.[id];


### PR DESCRIPTION
- Added "use client" directive to Projects.tsx to ensure it runs on the client side.
- Modified Projects.tsx to include error handling for the results data in the conditional rendering of ProjectItemAwarded.
- Updated useResults hook to call `api.results.results.useQuery` (publicProcedure) instead of `api.results.votes.useQuery` (adminProcedure) for fetching results data.
- Adjusted useProjectResults hook to align with the updated API endpoint.