### PR TITLE
fix: reintroduce projects endpoint in metricsRouter

### DIFF
--- a/src/server/api/routers/metrics/getProjects.ts
+++ b/src/server/api/routers/metrics/getProjects.ts
@@ -1,0 +1,53 @@
+import { fetchImpactMetrics } from "~/utils/fetchMetrics";
+import type { ImpactMetricsQuery } from "~/utils/fetchMetrics/types";
+import { mockedApprovedProjects } from "./mocks";
+
+type ProjectMetrics = Record<string, string | number>;
+type ProjectIdToMetricsMap = Record<string, ProjectMetrics>;
+
+export async function getProjects({
+  projectIds,
+  metricIds,
+}: {
+  projectIds: string[];
+  metricIds: string[];
+}): Promise<ProjectIdToMetricsMap> {
+  const approvedProjects = mockedApprovedProjects;
+
+  // Temporary mapping to OSO example projects
+  const tempProjectMap: Record<string, string> = Object.fromEntries(
+    projectIds.map((id, i) => [
+      approvedProjects[i % approvedProjects.length] ?? "",
+      id,
+    ]),
+  );
+
+  const query: ImpactMetricsQuery = {
+    where: {
+      project_name: { _in: Object.keys(tempProjectMap) },
+      event_source: { _eq: "BASE" },
+    },
+    orderBy: [{ active_contract_count_90_days: "desc" }],
+    limit: 300,
+    offset: 0,
+  };
+
+  const projects = await fetchImpactMetrics(query, metricIds);
+
+  const projectMetricsMap: ProjectIdToMetricsMap = Object.fromEntries(
+    projects.map((project) => {
+      // Replace with correct projectId
+      const projectId = tempProjectMap[project.project_name] ?? "";
+      const metrics = metricIds.reduce<ProjectMetrics>(
+        (acc, metricId) => ({
+          ...acc,
+          [metricId]: project[metricId as keyof typeof project],
+        }),
+        {},
+      );
+      return [projectId, metrics];
+    }),
+  );
+
+  return projectMetricsMap;
+}

--- a/src/server/api/routers/metrics/metricsRouter.ts
+++ b/src/server/api/routers/metrics/metricsRouter.ts
@@ -12,6 +12,7 @@ import { getMetrics } from "./getMetrics";
 import { fetchMetricsForRound } from "./fetchMetricsForRound";
 import { fetchMetricsForBallot } from "./fetchMetricsForBallots";
 import { fetchMetricsForProjects } from "./fetchMetricsForProjects";
+import { getProjects } from "./getProjects";
 
 export const metricsRouter = createTRPCRouter({
   get: publicProcedure
@@ -67,6 +68,20 @@ export const metricsRouter = createTRPCRouter({
           metricIds,
           roundId,
         });
+      } catch (error) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: (error as Error).message,
+        });
+      }
+    }),
+
+  projects: roundProcedure
+    .input(z.object({ projectIds: z.array(z.string()) }))
+    .query(async ({ input: { projectIds }, ctx }) => {
+      try {
+        const { metrics: metricIds } = ctx.round;
+        return getProjects({ projectIds, metricIds });
       } catch (error) {
         throw new TRPCError({
           code: "BAD_REQUEST",


### PR DESCRIPTION
Accidentally deleted in a previous PR after checking that was using mocked data and was not used by our app.
Reintroducing it because it's the endpoint used by the leaderboard.