### PR TITLE
fix: navbar in metrics page based on user

### DIFF
--- a/src/features/voters/hooks/useApprovedVoter.ts
+++ b/src/features/voters/hooks/useApprovedVoter.ts
@@ -2,9 +2,9 @@ import { type Address } from "viem";
 
 import { api } from "~/utils/api";
 
-export function useApprovedVoter(address: Address) {
+export function useApprovedVoter(address?: Address) {
   return api.voters.approved.useQuery(
-    { address },
+    { address: address! },
     { enabled: Boolean(address) },
   );
 }

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,0 +1,32 @@
+import { useAccount } from "wagmi";
+import { useCurrentRound } from "~/features/rounds/hooks/useRound";
+import { useApprovedVoter } from "~/features/voters/hooks/useApprovedVoter";
+
+export function useCurrentUser() {
+  const { address } = useAccount();
+  const { data: round, isPending: roundIsPending } = useCurrentRound();
+  const { data: approvedVoterData, isPending: approvedVoterIsPending } =
+    useApprovedVoter(address);
+
+  if (!address) {
+    return {
+      address,
+      isAdmin: false,
+      isPending: false,
+      isVoter: false,
+    };
+  }
+
+  const isAdmin = round?.admins.includes(address as string);
+
+  // useApprovedVoter returns a number, is a Voter is the number is greater than 0
+  const isVoter =
+    approvedVoterData !== undefined ? approvedVoterData > 0 : approvedVoterData;
+
+  return {
+    address,
+    isAdmin,
+    isPending: roundIsPending || approvedVoterIsPending,
+    isVoter,
+  };
+}

--- a/src/layouts/MetricsLayout.tsx
+++ b/src/layouts/MetricsLayout.tsx
@@ -1,11 +1,8 @@
 import type { ReactNode, PropsWithChildren } from "react";
 import Header from "~/components/Header";
 import { BaseLayout, type LayoutProps } from "./BaseLayout";
-import {
-  useCurrentDomain,
-  useCurrentRound,
-} from "~/features/rounds/hooks/useRound";
-import { useAccount } from "wagmi";
+import { useCurrentDomain } from "~/features/rounds/hooks/useRound";
+import { useCurrentUser } from "~/hooks/useCurrentUser";
 
 type Props = PropsWithChildren<
   {
@@ -16,21 +13,27 @@ type Props = PropsWithChildren<
 
 export const MetricsLayout = ({ children, ...props }: Props) => {
   const domain = useCurrentDomain();
-  const { address } = useAccount();
-  const { data: round, isPending } = useCurrentRound();
+  const { isAdmin, isVoter } = useCurrentUser();
 
   const navLinks = [
+    {
+      href: `/${domain}`,
+      children: `Round`,
+    },
     {
       href: `/${domain}/metrics`,
       children: `Metrics`,
     },
-    {
-      href: `/${domain}/ballot/metrics`,
-      children: `Ballot`,
-    },
   ];
 
-  if (round?.admins.includes(address!)) {
+  if (isVoter) {
+    navLinks.push({
+      href: `/${domain}/ballot/metrics`,
+      children: `Ballot`,
+    });
+  }
+
+  if (isAdmin) {
     navLinks.push(
       ...[
         {


### PR DESCRIPTION
When a user is not a voter we shouldn't display ballot navbar.

Also added a Round link in the navbar to allow users to go back to the round page