### PR TITLE
Multi award

### DIFF
--- a/src/features/distribute/components/Distributions.tsx
+++ b/src/features/distribute/components/Distributions.tsx
@@ -90,20 +90,43 @@ function DistributionTable({
   distributions: Distribution[];
 }) {
   return (
-    <div className="space-y-2 divide-y">
-      {distributions?.map((distribution) => (
-        <div key={distribution.projectId} className="flex items-center pt-3">
-          <div className="flex-1">
-            <div className="font-semibold">{distribution.name}</div>
-            <div className="font-mono text-sm">
-              {distribution.payoutAddress}
-            </div>
-          </div>
-          <div className="items-center">
-            {formatNumber(distribution.amount)}
-          </div>
-        </div>
-      ))}
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Project Name
+            </th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Payout Address
+            </th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Amount
+            </th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Amount Percentage
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {distributions?.map((distribution) => (
+            <tr key={distribution.projectId}>
+              <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                {distribution.name}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                {distribution.payoutAddress}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                {distribution.amount}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                {distribution.amountPercentage?.toFixed(2)} %
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
@@ -130,7 +153,7 @@ function ExportVotes(props:{
 
   return (
     <Button variant="outline" isLoading={isPending} onClick={exportCSV}>
-      Download votes ({props.totalVotes})
+      Download votes
     </Button>
   );
 }

--- a/src/features/distribute/types/index.ts
+++ b/src/features/distribute/types/index.ts
@@ -4,6 +4,7 @@ import { EthAddressSchema } from "~/features/rounds/types";
 export const DistributionSchema = z.object({
   projectId: z.string(),
   amount: z.number(),
+  amountPercentage: z.number().optional(),
   payoutAddress: EthAddressSchema,
 });
 

--- a/src/pages/[domain]/admin/distribute/index.tsx
+++ b/src/pages/[domain]/admin/distribute/index.tsx
@@ -19,7 +19,7 @@ export default function DistributePage() {
   return (
     <RoundAdminLayout>
       {() => (
-        <div className={round.data?.type == RoundType.impact ? "max-w-screen-md" : ""}>
+        <div>
           <div className="flex gap-3 mb-3">
             <div className="flex-1">
               <ConfigurePool/>

--- a/src/server/api/routers/ballot.ts
+++ b/src/server/api/routers/ballot.ts
@@ -153,12 +153,6 @@ export const ballotRouter = createTRPCRouter({
             ),
           ),
         );
-        if (ctx.round?.type !== "project") {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Export not implemented for impact Rounds",
-          });
-        }
         const projectsById = await createAttestationFetcher(ctx.round!)(
           ["metadata"],
           {

--- a/src/server/api/routers/results.ts
+++ b/src/server/api/routers/results.ts
@@ -233,7 +233,7 @@ function calculatePayout(
   totalTokens: bigint,
 ) {
   return (
-    (BigInt(Math.round(votes * 100)) * totalTokens) / BigInt(totalVotes) / 100n
+    (BigInt(Math.round(votes * 100)) * totalTokens) / BigInt(Math.round(totalVotes)) / 100n
   );
 }
 
@@ -383,11 +383,16 @@ async function generateImpactPayouts(round: Round, db: PrismaClient) {
     (sum, result) => sum + result.allocations,
     0,
   );
+  console.log("normalizedTotalVotes", normalizedTotalVotes);
+  
   const totalVoters = Object.values(combinedPayouts).reduce(
     (sum, result) => sum + result.voters,
     0,
   );
+  console.log("totalVoters", totalVoters);
+  
   const averageVotes = totalVoters > 0 ? normalizedTotalVotes / totalVoters : 0;
+  console.log("averageVotes", averageVotes);
 
   return {
     votes: combinedPayouts,

--- a/src/utils/awards.ts
+++ b/src/utils/awards.ts
@@ -1,0 +1,14 @@
+export const awards = [
+  {
+    id: "award1",
+    amount: 100, // pool amount for this award
+    metrics: ["address_count_90_days", "address_count"],
+    eligibleProjects: ["d51f7e0b-2f71-4818-b674-c9859b242a15", "1575c733-bec4-4e72-8620-79b3ff67e74f", "7a2b2cee-7512-4b9f-9dbc-677a8fa88388"],
+  },
+  {
+    id: "award2",
+    amount: 200, // pool amount for this award
+    metrics: ["gas_fees_sum", "days_since_first_transaction", "active_contract_count_90_days"],
+    eligibleProjects: ["d51f7e0b-2f71-4818-b674-c9859b242a15", "1575c733-bec4-4e72-8620-79b3ff67e74f"],
+  },
+];

--- a/src/utils/awards.ts
+++ b/src/utils/awards.ts
@@ -1,13 +1,13 @@
 export const awards = [
   {
     id: "award1",
-    amount: 1e18, // pool amount for this award
+    amount: 3e14, // 0.003
     metrics: ["address_count_90_days", "address_count"],
     eligibleProjects: ["d51f7e0b-2f71-4818-b674-c9859b242a15", "1575c733-bec4-4e72-8620-79b3ff67e74f", "7a2b2cee-7512-4b9f-9dbc-677a8fa88388"],
   },
   {
     id: "award2",
-    amount: 2e18, // pool amount for this award
+    amount: 7e14, // 0.007
     metrics: ["gas_fees_sum", "days_since_first_transaction", "active_contract_count_90_days"],
     eligibleProjects: ["d51f7e0b-2f71-4818-b674-c9859b242a15", "1575c733-bec4-4e72-8620-79b3ff67e74f"],
   },

--- a/src/utils/awards.ts
+++ b/src/utils/awards.ts
@@ -1,13 +1,13 @@
 export const awards = [
   {
     id: "award1",
-    amount: 100, // pool amount for this award
+    amount: 1e18, // pool amount for this award
     metrics: ["address_count_90_days", "address_count"],
     eligibleProjects: ["d51f7e0b-2f71-4818-b674-c9859b242a15", "1575c733-bec4-4e72-8620-79b3ff67e74f", "7a2b2cee-7512-4b9f-9dbc-677a8fa88388"],
   },
   {
     id: "award2",
-    amount: 200, // pool amount for this award
+    amount: 2e18, // pool amount for this award
     metrics: ["gas_fees_sum", "days_since_first_transaction", "active_contract_count_90_days"],
     eligibleProjects: ["d51f7e0b-2f71-4818-b674-c9859b242a15", "1575c733-bec4-4e72-8620-79b3ff67e74f"],
   },

--- a/src/utils/awards.ts
+++ b/src/utils/awards.ts
@@ -1,13 +1,13 @@
 export const awards = [
   {
     id: "award1",
-    amount: 3e14, // 0.003
+    amount: 3e13, // 0.0003
     metrics: ["address_count_90_days", "address_count"],
     eligibleProjects: ["d51f7e0b-2f71-4818-b674-c9859b242a15", "1575c733-bec4-4e72-8620-79b3ff67e74f", "7a2b2cee-7512-4b9f-9dbc-677a8fa88388"],
   },
   {
     id: "award2",
-    amount: 7e14, // 0.007
+    amount: 7e13, // 0.0007
     metrics: ["gas_fees_sum", "days_since_first_transaction", "active_contract_count_90_days"],
     eligibleProjects: ["d51f7e0b-2f71-4818-b674-c9859b242a15", "1575c733-bec4-4e72-8620-79b3ff67e74f"],
   },

--- a/src/utils/calculateResults.ts
+++ b/src/utils/calculateResults.ts
@@ -9,6 +9,7 @@ export type BallotResults = Record<
   {
     voters: number;
     allocations: number;
+    allocationPercentage?: number;
   }
 >;
 export function calculateVotes(


### PR DESCRIPTION
https://www.loom.com/share/08e2608d7d9b4497a77b0c927ef96669?sid=5a2991a0-81a9-4654-a474-c3637b7be300


closes PAR-276
closes PAR-277

note: this only generates the distribution data and doesn't actually store it
If we go down the award route and want a UI to show this infomration on the fly, we could choose to call the distribute endpoint to run calculations on the fly (it's not expensive) or save this in DB and have a cron to update the numbers every hour or so

This function would have to be updated to also return the project by award distribution if we want to use it on the leaderboard / other UI elements. 