### PR TITLE
Fix PAR-288 Add EmptyState to Metrics Page

### DIFF
--- a/src/features/metrics/components/MetricsList.tsx
+++ b/src/features/metrics/components/MetricsList.tsx
@@ -8,12 +8,18 @@ import { ErrorMessage } from "~/components/ErrorMessage";
 import { useMetrics } from "../hooks/useMetrics";
 import { Markdown } from "~/components/ui/Markdown";
 import { useCurrentUser } from "~/hooks/useCurrentUser";
+import { EmptyState } from "~/components/EmptyState";
 
 export function MetricsList() {
   const { data, error, isPending } = useMetrics();
 
   if (error) return <ErrorMessage error={error} />;
-
+  if (!isPending && !data.length)
+    return (
+      <EmptyState title="No metrics found">
+        This round has no metrics configured
+      </EmptyState>
+    );
   return (
     <section className="space-y-4">
       {isPending
@@ -34,7 +40,7 @@ function MetricCard({
   metric?: Metric;
 }) {
   const domain = useCurrentDomain();
-  const { isVoter} =  useCurrentUser();
+  const { isVoter } = useCurrentUser();
 
   return (
     <div className={"rounded border p-6 "}>
@@ -53,14 +59,17 @@ function MetricCard({
           {isLoading ? (
             <Skeleton isLoading className="block h-12" />
           ) : (
-            <Link href={`/${domain}/metrics/${metric?.id}`} className="hover:underline  underline-offset-2">
+            <Link
+              href={`/${domain}/metrics/${metric?.id}`}
+              className="underline-offset-2  hover:underline"
+            >
               <Markdown className={"line-clamp-2 text-gray-700"}>
                 {metric?.description}
               </Markdown>
             </Link>
           )}
         </div>
-        {isVoter &&  <AddToBallotButton id={metric?.id} /> }
+        {isVoter && <AddToBallotButton id={metric?.id} />}
       </div>
     </div>
   );


### PR DESCRIPTION
If no metrics configured it's currently a blank page. Show an empty state message.