### PR TITLE
run calculations only if round has applications

### DIFF
--- a/src/features/metrics/components/MetricsSidebar.tsx
+++ b/src/features/metrics/components/MetricsSidebar.tsx
@@ -112,34 +112,40 @@ export function MetricsSidebar({
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <div className="flex justify-end gap-1">
-            <MetricSort sort={sort} setSort={setSort} />
-          </div>
+          {list.length > 0 &&
+            <div className="flex justify-end gap-1">
+              <MetricSort sort={sort} setSort={setSort} />
+            </div>
+          }
         </div>
-        <ScrollArea className="relative max-h-[328px]">
-          {isLoading &&
-            Array(8)
-              .fill(0)
-              .map((_, i) => (
-                <AllocationItem key={i} isLoading>
-                  --
-                </AllocationItem>
-              ))}
-          {list.map((item) => (
-            <AllocationItem key={item.name} {...item}>
-              {formatAllocation(item.amount)}
-            </AllocationItem>
-          ))}
-          <div ref={intersectionRef} />
-          {(intersection?.intersectionRatio ?? 0) < 1 && (
-            <Badge
-              variant="outline"
-              className="animate-in fade-in zoom-in absolute bottom-2 left-1/2 -translate-x-1/2 bg-white"
-            >
-              More <ArrowDown className="ml-2 size-3 " />
-            </Badge>
-          )}
-        </ScrollArea>
+
+        {list.length > 0 ?
+          <ScrollArea className="relative max-h-[328px]">
+            {isLoading &&
+              Array(8)
+                .fill(0)
+                .map((_, i) => (
+                  <AllocationItem key={i} isLoading>
+                    --
+                  </AllocationItem>
+                ))}
+            {list.map((item) => (
+              <AllocationItem key={item.name} {...item}>
+                {formatAllocation(item.amount)}
+              </AllocationItem>
+            ))}
+            <div ref={intersectionRef} />
+            {(intersection?.intersectionRatio ?? 0) < 1 && (
+              <Badge
+                variant="outline"
+                className="animate-in fade-in zoom-in absolute bottom-2 left-1/2 -translate-x-1/2 bg-white"
+              >
+                More <ArrowDown className="ml-2 size-3 " />
+              </Badge>
+            )}
+          </ScrollArea>
+        : <div className="border py-3 rounded text-center text-muted-foreground text-sm">Metrics not set</div>
+        } 
 
         {footer}
       </div>

--- a/src/server/api/routers/metrics/utils/fetchMetricsForBallots.ts
+++ b/src/server/api/routers/metrics/utils/fetchMetricsForBallots.ts
@@ -43,16 +43,22 @@ export async function fetchMetricsForBallot({
     roundId,
   });
 
-  // const approvedProjects = mockedApprovedProjects; // For testing
-
   const approvedProjects = approvedApplications.map(
     (application) => application.name,
   );
+
+  if (approvedProjects.length === 0) {
+    return {
+      allocations: [],
+      projects: []
+    };
+  }
 
   const metricsByProject = await fetchImpactMetricsFromCSV({
     projects: approvedProjects,
     metrics: Object.keys(metricsById) as MetricId[],
   });
+
   const calculatedMetrics = calculateMetricsBallot(
     metricsByProject,
     metricsById,

--- a/src/server/api/routers/metrics/utils/fetchMetricsForProjects.ts
+++ b/src/server/api/routers/metrics/utils/fetchMetricsForProjects.ts
@@ -25,10 +25,13 @@ export async function fetchMetricsForProjects({
     roundId,
   });
 
-  // const approvedProjects = mockedApprovedProjects; // For testing
   const approvedProjects = approvedApplications.map(
     (application) => application.name,
   );
+
+  if (approvedProjects.length === 0) {
+    return [];
+  }
 
   const metricsByProject = await fetchImpactMetricsFromCSV({
     projects: approvedProjects,

--- a/src/server/api/routers/results.ts
+++ b/src/server/api/routers/results.ts
@@ -18,6 +18,7 @@ import { fetchImpactMetricsFromCSV } from "~/utils/fetchMetrics";
 import { MetricId } from "~/types/metrics";
 import { createDataFilter } from "~/utils/fetchAttestations";
 import { awards } from "~/utils/awards";
+import { fetchApprovedApplications } from "./applications/utils";
 
 export const resultsRouter = createTRPCRouter({
   distribution: adminAttestationProcedure
@@ -27,6 +28,15 @@ export const resultsRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+
+      const application = await ctx.fetchAttestations(["metadata"], {
+        where: { AND: [ createDataFilter("round", "bytes32", ctx.round.id)] },
+      });
+
+      if (application.length == 0) {
+        return [];
+      }
+
       const votes = await calculateBallotResults(ctx);
 
       const totalVotes = votes.totalVotes;

--- a/src/utils/awards.ts
+++ b/src/utils/awards.ts
@@ -1,14 +1,38 @@
-export const awards = [
-  {
-    id: "award1",
-    amount: 3e14, // 0.0003
-    metrics: ["address_count_90_days", "address_count"],
-    eligibleProjects: ["bfcecf54-5f57-42f9-80e1-613cb5cbd38d", "afba08a9-db09-49db-8fa3-58255bc2b528", "3f3f5ee5-3a0b-4a46-800c-3b2a0bf203b4"],
-  },
-  {
-    id: "award2",
-    amount: 7e14, // 0.0007
-    metrics: ["gas_fees_sum", "days_since_first_transaction", "active_contract_count_90_days"],
-    eligibleProjects: ["bfcecf54-5f57-42f9-80e1-613cb5cbd38d", "afba08a9-db09-49db-8fa3-58255bc2b528"],
-  },
-];
+export type RoundAwards = {
+  [roundId: string]: Award[];
+};
+
+export type Award = {
+  id: string;
+  amount: number;
+  metrics: string[];
+  eligibleProjects: string[];
+};
+
+export const roundAwards: RoundAwards = {
+  "cm0dl93qb003q1381pklk5ib8": [
+    {
+      id: "award1",
+      amount: 3e14, // 0.0003
+      metrics: ["address_count_90_days", "address_count"],
+      eligibleProjects: [
+        "bfcecf54-5f57-42f9-80e1-613cb5cbd38d",
+        "afba08a9-db09-49db-8fa3-58255bc2b528",
+        "3f3f5ee5-3a0b-4a46-800c-3b2a0bf203b4",
+      ],
+    },
+    {
+      id: "award2",
+      amount: 7e14, // 0.0007
+      metrics: [
+        "gas_fees_sum",
+        "days_since_first_transaction",
+        "active_contract_count_90_days",
+      ],
+      eligibleProjects: [
+        "bfcecf54-5f57-42f9-80e1-613cb5cbd38d",
+        "afba08a9-db09-49db-8fa3-58255bc2b528",
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
Ensures data for
- calculations
- metrics 

load only when applications are present for a round and doesn't default to what is defined on the csv

![Deploy](https://github.com/user-attachments/assets/79e4208e-7155-4940-83f7-cb748c3136cd)

