### PR TITLE
tweak logic to account only for metrics and projects in award

### DIFF
--- a/src/server/api/routers/results.ts
+++ b/src/server/api/routers/results.ts
@@ -283,19 +283,17 @@ async function generateImpactPayouts(round: Round, db: PrismaClient) {
     const projectMetrics = normalizeData(eligibleProjectMetrics);
     console.log("normalize metric from 0 -> 1", projectMetrics);
 
-    // Filter allocations to include only those relevant to the current award metrics
-    const filteredAllocations = allocations.filter((allocation) => {
-      // Check if the allocation's metric ID is part of the current award's metrics
-      return metrics.includes(allocation.id);
-    });
-    console.log("Filtered Allocations", filteredAllocations.length, filteredAllocations);
-
     // Calculate metricAmounts considering only eligible projects for this award
-    const filteredMetricAmounts = filteredAllocations.reduce(
+    const filteredMetricAmounts = allocations.reduce(
       (accumulator, allocation) => {
-        if (metrics.includes(allocation.id as MetricId)) {
+        // Check if the allocation's metric ID is part of the current award's metrics
+        if (metrics.includes(allocation.id)) {
+          // Update the accumulator with the allocation amount
           accumulator[allocation.id] =
             (accumulator[allocation.id] || 0) + allocation.amount;
+
+          // Print the filtered metric and its updated amount
+          console.log(`Filtered Metric ID: ${allocation.id}, Amount: ${accumulator[allocation.id]}`);
         }
         return accumulator;
       },

--- a/src/server/api/routers/results.ts
+++ b/src/server/api/routers/results.ts
@@ -283,16 +283,12 @@ async function generateImpactPayouts(round: Round, db: PrismaClient) {
     const projectMetrics = normalizeData(eligibleProjectMetrics);
     console.log("normalize metric from 0 -> 1", projectMetrics);
 
-    // Filter allocations to only include those that belong to eligible projects
+    // Filter allocations to include only those relevant to the current award metrics
     const filteredAllocations = allocations.filter((allocation) => {
-      // Find the project associated with this allocation metric
-      const projectForMetric = projectMetrics.find((p) =>
-        eligibleProjects.includes(p.project_id) && allocation.id in p
-      );
-    
-      return projectForMetric !== undefined; // Only keep allocations with eligible projects
+      // Check if the allocation's metric ID is part of the current award's metrics
+      return metrics.includes(allocation.id);
     });
-    console.log("filteredAllocations", filteredAllocations.length ,filteredAllocations);
+    console.log("Filtered Allocations", filteredAllocations.length, filteredAllocations);
 
     // Calculate metricAmounts considering only eligible projects for this award
     const filteredMetricAmounts = filteredAllocations.reduce(


### PR DESCRIPTION
Update the logic to ensure when we calculate the distribution for an award 

- ensure only project and metrics for a given award are considered 
- and all metric from csv for the projects taking part in the award are normalized to a score between 0 to 1 to ensure equal weightage

Test using: http://localhost:3000/test-round/admin/distribute