### PR TITLE
fix: check session address to know if user is connected

### DIFF
--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -102,11 +102,12 @@ const ConnectedDetails = ({
   openAccountModal: () => void;
   isMobile: boolean;
 }) => {
-  const { data: ballot } = useBallot();
+  const { eligibilityCheck, showBallot } = useLayoutOptions();
+
+  const { data: ballot } = useBallot({ enabled: showBallot });
   const ballotSize = (ballot?.allocations ?? []).length;
   const domain = useCurrentDomain();
 
-  const { eligibilityCheck, showBallot } = useLayoutOptions();
   return (
     <div>
       <div className="flex gap-2">

--- a/src/components/EligibilityDialog.tsx
+++ b/src/components/EligibilityDialog.tsx
@@ -1,18 +1,17 @@
 import Link from "next/link";
-import { useAccount, useDisconnect } from "wagmi";
-import { useSession } from "next-auth/react";
+import { useDisconnect } from "wagmi";
 
 import { metadata } from "~/config";
 import { Dialog } from "./ui/Dialog";
 import { useApprovedVoter } from "~/features/voters/hooks/useApprovedVoter";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 export const EligibilityDialog = () => {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const { disconnect } = useDisconnect();
-  const { data: session } = useSession();
-  const { data, isPending, error } = useApprovedVoter(address!);
+  const { data, isPending, error } = useApprovedVoter(address);
 
-  if (isPending || !address || !session || error) return null;
+  if (isPending || !address || error) return null;
 
   // TODO: Find a smoother UX for this
   if (true) return null;

--- a/src/features/admin/layouts/AdminLayout.tsx
+++ b/src/features/admin/layouts/AdminLayout.tsx
@@ -14,10 +14,10 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRouter } from "next/router";
 import { createElement, type ReactNode } from "react";
-import { useAccount } from "wagmi";
 import { Spinner } from "~/components/ui/Spinner";
 import { useCurrentRound } from "~/features/rounds/hooks/useRound";
 import { type RoundSchema } from "~/features/rounds/types";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 import { Layout } from "~/layouts/DefaultLayout";
 import { cn } from "~/utils/classNames";
 
@@ -33,7 +33,7 @@ export function RoundAdminLayout({
     params: UseTRPCQueryResult<RoundSchema | null, unknown>,
   ) => ReactNode;
 }) {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const round = useCurrentRound();
 
   return (

--- a/src/features/applications/components/ApplicationForm.tsx
+++ b/src/features/applications/components/ApplicationForm.tsx
@@ -5,8 +5,7 @@ import { type Address } from "viem";
 import { toast } from "sonner";
 import { useController, useFormContext } from "react-hook-form";
 import { useLocalStorage } from "react-use";
-import { useSession } from "next-auth/react";
-import { useAccount, useBalance } from "wagmi";
+import { useBalance } from "wagmi";
 
 import { ImageUpload } from "~/components/ImageUpload";
 import { Button } from "~/components/ui/Button";
@@ -34,6 +33,7 @@ import { Alert } from "~/components/ui/Alert";
 import { useCurrentRound } from "~/features/rounds/hooks/useRound";
 import { useRoundState } from "~/features/rounds/hooks/useRoundState";
 import { EnsureCorrectNetwork } from "~/components/EnsureCorrectNetwork";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 const ApplicationCreateSchema = z.object({
   profile: ProfileSchema,
@@ -337,10 +337,9 @@ function CreateApplicationButton({
   buttonText: string;
 }) {
   const roundState = useRoundState();
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const balance = useBalance({ address });
 
-  const { data: session } = useSession();
   const { isCorrectNetwork, correctNetwork } = useIsCorrectNetwork();
 
   const hasBalance = (balance.data?.value ?? 0n) > 0;
@@ -348,7 +347,7 @@ function CreateApplicationButton({
   return (
     <div className="flex items-center justify-between">
       <div>
-        {!session && (
+        {!address && (
           <div>You must connect wallet to create an application</div>
         )}
         {!isCorrectNetwork && (
@@ -365,7 +364,7 @@ function CreateApplicationButton({
       <EnsureCorrectNetwork>
         {hasBalance ? (
           <Button
-            disabled={roundState !== "APPLICATION" || isLoading || !session}
+            disabled={roundState !== "APPLICATION" || isLoading || !address}
             variant="primary"
             type="submit"
             isLoading={isLoading}

--- a/src/features/ballot/components/SubmitBallotButton.tsx
+++ b/src/features/ballot/components/SubmitBallotButton.tsx
@@ -10,16 +10,16 @@ import {
   useCurrentRound,
 } from "~/features/rounds/hooks/useRound";
 import { useApprovedVoter } from "~/features/voters/hooks/useApprovedVoter";
-import { useAccount } from "wagmi";
 import {
   useBallot,
   useIsSavingBallot,
 } from "~/features/ballot/hooks/useBallot";
 import Link from "next/link";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 export const SubmitBallotButton = ({ disabled = false }) => {
   const router = useRouter();
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const { data: ballot } = useBallot();
   const isSaving = useIsSavingBallot();
 

--- a/src/features/ballot/hooks/useBallot.ts
+++ b/src/features/ballot/hooks/useBallot.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMutation } from "@tanstack/react-query";
 import { useBeforeUnload } from "react-use";
 import { useChainId, useSignTypedData } from "wagmi";
@@ -11,8 +13,9 @@ import { getQueryKey } from "@trpc/react-query";
 import { useBallotContext } from "~/features/ballot/components/BallotProvider";
 import { api } from "~/utils/api";
 
-export function useBallot() {
-  return api.ballot.get.useQuery();
+export function useBallot(opts?: { enabled?: boolean }) {
+  const enabled = opts?.enabled ?? true;
+  return api.ballot.get.useQuery(undefined, { enabled });
 }
 
 export function useSaveAllocation() {

--- a/src/features/distribute/components/CreatePool.tsx
+++ b/src/features/distribute/components/CreatePool.tsx
@@ -2,8 +2,6 @@ import { type PropsWithChildren } from "react";
 import { z } from "zod";
 import dynamic from "next/dynamic";
 import { formatUnits, parseUnits } from "viem";
-import { useAccount } from "wagmi";
-import { useSession } from "next-auth/react";
 import { useFormContext } from "react-hook-form";
 
 import { Button, IconButton } from "~/components/ui/Button";
@@ -20,7 +18,6 @@ import {
   usePoolToken,
   useRoundToken,
 } from "../hooks/useAlloPool";
-import { allo } from "~/config";
 import {
   ErrorMessage,
   Form,
@@ -29,6 +26,7 @@ import {
   Label,
 } from "~/components/ui/Form";
 import { NumberInput } from "~/components/NumberInput";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 function CheckAlloProfile(props: PropsWithChildren) {
   const { isCorrectNetwork, correctNetwork } = useIsCorrectNetwork();
@@ -186,7 +184,6 @@ function PoolDetails({ poolId = 0 }) {
         </div>
       </div>
 
-
       <h3 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
         Fund Pool Amount
       </h3>
@@ -257,8 +254,7 @@ function FundPoolButton({
   isLoading?: boolean;
   token: TokenProps;
 }) {
-  const { address } = useAccount();
-  const session = useSession();
+  const { address } = useSessionAddress();
   const { formState, watch } = useFormContext<{ amount: number }>();
   const amount = watch("amount") || 0;
 
@@ -269,7 +265,7 @@ function FundPoolButton({
 
   const disabled = isLoading || Boolean(formState.errors.amount);
 
-  if (!address || !session) {
+  if (!address) {
     return (
       <Button className="w-full" disabled>
         Connect wallet

--- a/src/features/distribute/hooks/useAlloPool.ts
+++ b/src/features/distribute/hooks/useAlloPool.ts
@@ -1,5 +1,4 @@
 import {
-  useAccount,
   useBalance,
   usePublicClient,
   useReadContract,
@@ -21,6 +20,7 @@ import {
   useUpdateRound,
 } from "~/features/rounds/hooks/useRound";
 import { toast } from "sonner";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 export function usePoolId() {
   const round = useCurrentRound();
@@ -90,7 +90,7 @@ export function useCreatePool() {
       // This will properly cast the type into address (and also validate)
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const token = getAddress(round.tokenAddress || nativeToken);
-      const managers = round.admins.map(admin => getAddress(admin));
+      const managers = round.admins.map((admin) => getAddress(admin));
 
       const tx = alloSDK.createPool({
         profileId: params.profileId as Address,
@@ -162,7 +162,7 @@ export function useFundPool() {
 }
 
 function useToken(tokenAddress?: Address) {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const { data: round } = useCurrentRound();
   const isNativeToken = !tokenAddress || tokenAddress === nativeToken;
   const tokenContract = {
@@ -195,7 +195,7 @@ function useToken(tokenAddress?: Address) {
     data: {
       address: tokenAddress,
       isNativeToken,
-      symbol: isNativeToken ? network?.nativeCurrency.name : symbol ?? "",
+      symbol: isNativeToken ? network?.nativeCurrency.name : (symbol ?? ""),
       balance: balance?.value ?? 0n,
       decimals,
       allowance,
@@ -218,7 +218,7 @@ export function usePoolToken() {
 }
 
 export function useTokenAllowance() {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const { data } = useRoundToken();
 
   const query = useReadContract({

--- a/src/features/distribute/hooks/useAlloProfile.ts
+++ b/src/features/distribute/hooks/useAlloProfile.ts
@@ -1,13 +1,14 @@
-import { useAccount, usePublicClient, useSendTransaction } from "wagmi";
+import { usePublicClient, useSendTransaction } from "wagmi";
 import { abi as RegistryABI } from "@allo-team/allo-v2-sdk/dist/Registry/registry.config";
 import { type Address, zeroAddress } from "viem";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { solidityPackedKeccak256 } from "ethers";
 import { useAlloRegistry, waitForLogs } from "./useAllo";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 export function useAlloProfile() {
   const registry = useAlloRegistry();
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
 
   return useQuery({
     queryKey: ["allo/profile"],
@@ -24,7 +25,7 @@ export function useAlloProfile() {
 const NONCE = 3n;
 export function useCreateAlloProfile() {
   const registry = useAlloRegistry();
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const client = usePublicClient();
   const { sendTransactionAsync } = useSendTransaction();
   const queryClient = useQueryClient();

--- a/src/features/projects/components/AddToBallot.tsx
+++ b/src/features/projects/components/AddToBallot.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { z } from "zod";
 import clsx from "clsx";
-import { useAccount } from "wagmi";
 import { useFormContext } from "react-hook-form";
 import { Check } from "lucide-react";
 
@@ -18,11 +17,12 @@ import {
   useRemoveAllocation,
   useSaveAllocation,
 } from "~/features/ballot/hooks/useBallot";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 type Props = { id: string; name?: string };
 
 export const ProjectAddToBallot = ({ id, name }: Props) => {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const [isOpen, setOpen] = useState(false);
 
   const ballot = useBallot();

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,9 +1,9 @@
-import { useAccount } from "wagmi";
 import { useCurrentRound } from "~/features/rounds/hooks/useRound";
 import { useApprovedVoter } from "~/features/voters/hooks/useApprovedVoter";
+import { useSessionAddress } from "./useSessionAddress";
 
 export function useCurrentUser() {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const { data: round, isPending: roundIsPending } = useCurrentRound();
   const { data: approvedVoterData, isPending: approvedVoterIsPending } =
     useApprovedVoter(address);

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -1,8 +1,8 @@
-import { useAccount } from "wagmi";
 import { useCurrentRound } from "~/features/rounds/hooks/useRound";
+import { useSessionAddress } from "./useSessionAddress";
 
 export function useIsAdmin() {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const round = useCurrentRound();
   return round.data?.admins.includes(address!);
 }

--- a/src/hooks/useSessionAddress.ts
+++ b/src/hooks/useSessionAddress.ts
@@ -1,0 +1,10 @@
+import { useSession } from "next-auth/react";
+
+export function useSessionAddress() {
+  const { data: session } = useSession();
+  const address = (session?.user?.name ?? undefined) as
+    | `0x${string}`
+    | undefined;
+
+  return { address };
+}

--- a/src/layouts/BaseLayout.tsx
+++ b/src/layouts/BaseLayout.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "next/router";
 import { metadata } from "~/config";
 import { useTheme } from "next-themes";
 import { Footer } from "~/components/Footer";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 const Context = createContext({ eligibilityCheck: false, showBallot: false });
 export const useLayoutOptions = () => useContext(Context);
@@ -41,12 +42,12 @@ export const BaseLayout = ({
 >) => {
   const { theme } = useTheme();
   const router = useRouter();
-  const { address, isConnecting } = useAccount();
+  const { address } = useSessionAddress();
+  const { isConnecting } = useAccount();
 
   useEffect(() => {
     if (requireAuth && !address && !isConnecting) {
       void router.push("/");
-      return null;
     }
   }, [requireAuth, address, isConnecting]);
 

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { ReactNode, PropsWithChildren } from "react";
-import { useAccount } from "wagmi";
 
 import Header from "~/components/Header";
 import BallotOverview from "~/features/ballot/components/BallotOverview";
@@ -11,10 +10,10 @@ import {
   useCurrentRound,
 } from "~/features/rounds/hooks/useRound";
 import { useRoundState } from "~/features/rounds/hooks/useRoundState";
-import { useSession } from "next-auth/react";
 import { Button } from "~/components/ui/Button";
 import Link from "next/link";
 import { RoundTypes } from "~/features/rounds/types";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 type Props = PropsWithChildren<
   {
@@ -23,7 +22,7 @@ type Props = PropsWithChildren<
   } & LayoutProps
 >;
 export const Layout = ({ children, ...props }: Props) => {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
 
   const domain = useCurrentDomain();
   const { data: round, isPending } = useCurrentRound();
@@ -98,12 +97,11 @@ export const Layout = ({ children, ...props }: Props) => {
 };
 
 export function LayoutWithBallot(props: Props) {
-  const { address } = useAccount();
-  const { data: session } = useSession();
+  const { address } = useSessionAddress();
   return (
     <Layout
       sidebar="left"
-      sidebarComponent={address && session && <BallotOverview />}
+      sidebarComponent={address && <BallotOverview />}
       {...props}
     />
   );

--- a/src/layouts/MetricsLayout.tsx
+++ b/src/layouts/MetricsLayout.tsx
@@ -7,7 +7,6 @@ import { useCurrentDomain } from "~/features/rounds/hooks/useRound";
 import { useCurrentUser } from "~/hooks/useCurrentUser";
 import { useRoundState } from "~/features/rounds/hooks/useRoundState";
 import { Spinner } from "~/components/ui/Spinner";
-import { useAccount } from "wagmi";
 import { HandIcon, PauseIcon, WalletIcon } from "lucide-react";
 import { Alert } from "~/components/ui/Alert";
 
@@ -24,9 +23,8 @@ export const MetricsLayout = ({
   ...props
 }: Props) => {
   const domain = useCurrentDomain();
-  const { isAdmin, isVoter, isPending } = useCurrentUser();
+  const { address, isAdmin, isVoter, isPending } = useCurrentUser();
   const roundState = useRoundState();
-  const { address } = useAccount();
 
   const isVotingPhase = roundState === "VOTING";
 

--- a/src/pages/[domain]/admin/voters/index.tsx
+++ b/src/pages/[domain]/admin/voters/index.tsx
@@ -19,12 +19,12 @@ import { NumberInput } from "~/components/NumberInput";
 import { useUpdateRound } from "~/features/rounds/hooks/useRound";
 import { Alert } from "~/components/ui/Alert";
 import { useRevokeAttestations } from "~/hooks/useRevokeAttestations";
-import { useAccount } from "wagmi";
 import { VotersList } from "~/features/admin/components/VotersList";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 export default function AdminAccountsPage() {
   const [isOpen, setOpen] = useState(false);
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
   const update = useUpdateRound();
   const { data: voterList } = useVoters();
   const approve = useApproveVoters({

--- a/src/pages/[domain]/applications/new.tsx
+++ b/src/pages/[domain]/applications/new.tsx
@@ -3,13 +3,13 @@
 import { Layout } from "~/layouts/DefaultLayout";
 
 import { ApplicationForm } from "~/features/applications/components/ApplicationForm";
-import { useAccount } from "wagmi";
 import { Alert } from "~/components/ui/Alert";
 import { FormSection } from "~/components/ui/Form";
 import { useRoundState } from "~/features/rounds/hooks/useRoundState";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 export default function NewProjectPage() {
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
 
   const roundState = useRoundState();
   const isNotApplicationPeriod = roundState !== "APPLICATION";

--- a/src/pages/create-round/index.tsx
+++ b/src/pages/create-round/index.tsx
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { useAccount } from "wagmi";
 import { Button } from "~/components/ui/Button";
 import { Form, FormControl, FormSection, Input } from "~/components/ui/Form";
 import { ConnectButton } from "~/components/ConnectButton";
@@ -7,6 +6,7 @@ import { BaseLayout } from "~/layouts/BaseLayout";
 import { api } from "~/utils/api";
 import { useRouter } from "next/router";
 import { RoundNameSchema } from "~/features/rounds/types";
+import { useSessionAddress } from "~/hooks/useSessionAddress";
 
 export default function CreateRoundPage() {
   return (
@@ -20,7 +20,7 @@ export default function CreateRoundPage() {
 
 function CreateRound() {
   const router = useRouter();
-  const { address } = useAccount();
+  const { address } = useSessionAddress();
 
   const create = api.rounds.create.useMutation();
 


### PR DESCRIPTION
- implemented useSessionAddress hook
- use the session address to check if user is connected, instead of wagmi address

Context:

In our app we consider that the user is connected if the user signed the session,
we are experiencing conflicts where there is no session, but wagmi is connected,
also sometimes the client doesn't have session, but the server maintains the previous session,
leading to incorrect backend behavior with a wrong address.

Once a new session is established in the client, then the server will have the right address.

To avoid this conflict, we should check if there is a session or not => useSessionAddress